### PR TITLE
BuildKit and build-arg support

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -388,7 +388,7 @@ def make_r2d(argv=None):
 
     r2d.extra_build_args = {}
     for build_arg in args.extra_build_args:
-        kv = build_arg.split(":")
+        kv = build_arg.split("=")
         r2d.extra_build_args[kv[0]] = kv[1]
 
     # if the source exists locally we don't want to delete it at the end

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -234,8 +234,8 @@ def get_argparser():
         dest="extra_build_args",
         action="append",
         help="Additional build arguments",
+        default=[],
     )
-
 
     return argparser
 

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -229,6 +229,14 @@ def get_argparser():
         # help=self.traits()['entrypoint_file'].help,
     )
 
+    argparser.add_argument(
+        "--build-arg",
+        dest="extra_build_args",
+        action="append",
+        help="Additional build arguments",
+    )
+
+
     return argparser
 
 
@@ -377,6 +385,11 @@ def make_r2d(argv=None):
         r2d.cache_from = args.cache_from
 
     r2d.environment = args.environment
+
+    r2d.extra_build_args = {}
+    for build_arg in args.extra_build_args:
+        kv = build_arg.split(":")
+        r2d.extra_build_args[kv[0]] = kv[1]
 
     # if the source exists locally we don't want to delete it at the end
     # FIXME: Find a better way to figure out if repo is 'local'. Push this into ContentProvider?

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -40,6 +40,7 @@ from .buildpacks import (
 )
 from . import contentproviders
 from .utils import ByteSpecification, chdir
+from .docker_utils import DockerCLI
 
 
 class Repo2Docker(Application):
@@ -659,7 +660,7 @@ class Repo2Docker(Application):
         # Check if r2d can connect to docker daemon
         if not self.dry_run:
             try:
-                docker_client = docker.APIClient(version="auto", **kwargs_from_env())
+                docker_client = DockerCLI()
             except DockerException as e:
                 self.log.error(
                     "\nDocker client initialization error: %s.\nCheck if docker is running on the host.\n",

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -128,6 +128,16 @@ class Repo2Docker(Application):
         config=True,
     )
 
+    extra_build_args = Dict(
+        {},
+        help="""
+        Regular Docker build-time  arguments that will be passed as 
+        --build-arg key=value. 
+        Reference https://docs.docker.com/engine/reference/commandline/build/
+        """,
+        config=True,
+    )
+
     default_buildpack = Any(
         PythonBuildPack,
         config=True,
@@ -734,6 +744,8 @@ class Repo2Docker(Application):
                         bp.__class__.__name__,
                         extra=dict(phase="building"),
                     )
+
+                    build_args.update(extra_build_args)
 
                     for l in picked_buildpack.build(
                         docker_client,

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -131,8 +131,8 @@ class Repo2Docker(Application):
     extra_build_args = Dict(
         {},
         help="""
-        Regular Docker build-time  arguments that will be passed as 
-        --build-arg key=value. 
+        Regular Docker build-time  arguments that will be passed as
+        --build-arg key=value.
         Reference https://docs.docker.com/engine/reference/commandline/build/
         """,
         config=True,
@@ -745,7 +745,7 @@ class Repo2Docker(Application):
                         extra=dict(phase="building"),
                     )
 
-                    build_args.update(extra_build_args)
+                    build_args.update(self.extra_build_args)
 
                     for l in picked_buildpack.build(
                         docker_client,

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -579,7 +579,8 @@ class Repo2Docker(Application):
                 version="auto", **docker.utils.kwargs_from_env()
             )
             image = api_client.inspect_image(self.output_image_spec)
-            image_workdir = image["ContainerConfig"]["WorkingDir"]
+            # Buildkit uses Config/WorkingDir not ContainerConfig/WorkingDir
+            image_workdir = image["Config"]["WorkingDir"]
 
             for k, v in self.volumes.items():
                 container_volumes[os.path.abspath(k)] = {

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -86,6 +86,13 @@ RUN apt-get -qq update && \
 
 EXPOSE 8888
 
+{% if build_args -%}
+# Arguments required for build
+{% for item in build_args -%}
+ARG {{item}}
+{% endfor -%}
+{% endif -%}
+
 {% if build_env -%}
 # Environment variables required for build
 {% for item in build_env -%}
@@ -508,6 +515,7 @@ class BuildPack:
             packages=sorted(self.get_packages()),
             path=self.get_path(),
             build_env=self.get_build_env(),
+            build_args=self.get_build_args(),
             env=self.get_env(),
             labels=self.get_labels(),
             build_script_directives=build_script_directives,

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -10,7 +10,6 @@ import sys
 import hashlib
 import escapism
 import xml.etree.ElementTree as ET
-from ..docker_utils import docker_build
 
 from traitlets import Dict
 
@@ -664,7 +663,7 @@ class BuildPack:
 
         build_kwargs.update(extra_build_kwargs)
 
-        for line in docker_build(**build_kwargs):
+        for line in client.build(**build_kwargs):
             yield line
 
 

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -10,11 +10,12 @@ import sys
 import hashlib
 import escapism
 import xml.etree.ElementTree as ET
+from ..docker_utils import docker_build
 
 from traitlets import Dict
 
-# Only use syntax features supported by Docker 17.09
-TEMPLATE = r"""
+# Use new buildkit syntax features
+TEMPLATE = r"""# syntax=docker/dockerfile:experimental
 FROM buildpack-deps:bionic
 
 # Avoid prompts from apt
@@ -657,7 +658,7 @@ class BuildPack:
 
         build_kwargs.update(extra_build_kwargs)
 
-        for line in client.build(**build_kwargs):
+        for line in docker_build(**build_kwargs):
             yield line
 
 

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -321,6 +321,12 @@ class BuildPack:
         """
         return {}
 
+    def get_build_args(self):
+        """
+        List of build arguments set on image, used with --build-args.
+        """
+        return []
+
     def _check_stencila(self):
         """Find the stencila manifest dir if it exists
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -103,10 +103,7 @@ class RBuildPack(PythonBuildPack):
         if not hasattr(self, "_checkpoint_date"):
             match = re.match(r"r-(\d.\d(.\d)?-)?(\d\d\d\d)-(\d\d)-(\d\d)", self.runtime)
             if not match:
-                # no R snapshot date set through runtime.txt so set
-                # to a reasonable default -- the last month of the previous
-                # quarter
-                self._checkpoint_date = self.mran_date(datetime.date.today())
+                self._checkpoint_date = False
             else:
                 # turn the last three groups of the match into a date
                 self._checkpoint_date = datetime.date(

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -131,7 +131,8 @@ class RBuildPack(PythonBuildPack):
                 # no R snapshot date set through runtime.txt so set
                 # to a reasonable default -- the last month of the previous
                 # quarter
-                self._checkpoint_date = self.mran_date(datetime.date.today())
+                quarter = self.mran_date(datetime.date.today())
+                self._checkpoint_date = self._get_latest_working_mran_date(quarter, 3)
                 self._runtime = "r-{}".format(str(self._checkpoint_date))
             return True
 

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -30,6 +30,7 @@ class DockerCLI:
         container_limits=None,
         cache_from=None,
         path=None,
+        dockerfile=None,
         **extra_build_kwargs,
     ):
 
@@ -38,11 +39,18 @@ class DockerCLI:
         if tag is not None:
             build_cmd = build_cmd + " --tag " + tag
 
+        if path is not None:
+            os.chdir(path)
+
+        if dockerfile is not None:
+            build_cmd = build_cmd + " -f " + dockerfile
+
         tempdir = tempfile.mkdtemp()
         if fileobj is not None:
             tar = tarfile.open(fileobj=fileobj, mode="r")
             tar.extractall(tempdir)
             tar.close()
+            path = tempdir
 
         if buildargs is not None:
             for key, value in buildargs.items():
@@ -65,9 +73,8 @@ class DockerCLI:
             for cache in cache_from:
                 build_cmd = build_cmd + " " + cache
 
-        build_cmd = build_cmd + " " + tempdir
+        build_cmd = build_cmd + " " + path
 
-        print(build_cmd)
         with subprocess.Popen(
             build_cmd,
             shell=True,

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -1,0 +1,63 @@
+"""
+"""
+
+import tarfile
+import tempfile
+import shutil
+import json
+import subprocess
+import os
+
+
+def docker_build(fileobj=None, tag=None, custom_context=False, buildargs=None,
+                 decode=False, forcerm=False, rm=False, container_limits=None,
+                 cache_from=None, **extra_build_kwargs):
+
+    build_cmd = 'docker build --progress plain'
+
+    if tag is not None:
+        build_cmd = build_cmd + ' --tag ' + tag
+
+    tempdir = tempfile.mkdtemp()
+    if fileobj is not None:
+        tar = tarfile.open(fileobj=fileobj, mode="r")
+        tar.extractall(tempdir)
+        tar.close()
+
+    if buildargs is not None:
+        for key, value in buildargs.items():
+            build_cmd = build_cmd + ' --build-arg ' + key + '=' + value
+
+    # TODO: Handle extra_build_kwargs?
+
+    if forcerm:
+        build_cmd = build_cmd + ' --force-rm'
+
+    if rm:
+        build_cmd = build_cmd + ' --rm'
+
+    if container_limits is not None:
+        if 'memlimit' in container_limits:
+            build_cmd = build_cmd + ' --memory ' + container_limits['memlimit']
+
+    if cache_from:
+        build_cmd = build_cmd + ' --cache-from'
+        for cache in cache_from:
+            build_cmd = build_cmd + ' ' + cache
+
+    build_cmd = build_cmd + ' ' + tempdir
+
+    with subprocess.Popen(build_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            universal_newlines=True, env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"}) as p:
+
+        while True:
+            line = p.stdout.readline()
+            if not line:
+                break
+            yield {"stream": line}
+
+        rc = p.poll()
+        if rc != 0:
+          yield {"error": line}
+
+    shutil.rmtree(tempdir)

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -1,6 +1,7 @@
 """
 """
 
+import docker
 import tarfile
 import tempfile
 import shutil
@@ -9,70 +10,81 @@ import subprocess
 import os
 
 
-def docker_build(
-    fileobj=None,
-    tag=None,
-    custom_context=False,
-    buildargs=None,
-    decode=False,
-    forcerm=False,
-    rm=False,
-    container_limits=None,
-    cache_from=None,
-    **extra_build_kwargs,
-):
+class DockerCLI:
+    def __init__(self):
+        cp = subprocess.run(
+            ["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        if cp.returncode:
+            raise docker.errors.DockerException("no Docker")
 
-    build_cmd = "docker build --progress plain"
+    def build(
+        self,
+        fileobj=None,
+        tag=None,
+        custom_context=False,
+        buildargs=None,
+        decode=False,
+        forcerm=False,
+        rm=False,
+        container_limits=None,
+        cache_from=None,
+        path=None,
+        **extra_build_kwargs,
+    ):
 
-    if tag is not None:
-        build_cmd = build_cmd + " --tag " + tag
+        build_cmd = "docker build --progress plain"
 
-    tempdir = tempfile.mkdtemp()
-    if fileobj is not None:
-        tar = tarfile.open(fileobj=fileobj, mode="r")
-        tar.extractall(tempdir)
-        tar.close()
+        if tag is not None:
+            build_cmd = build_cmd + " --tag " + tag
 
-    if buildargs is not None:
-        for key, value in buildargs.items():
-            build_cmd = build_cmd + " --build-arg " + key + "=" + value
+        tempdir = tempfile.mkdtemp()
+        if fileobj is not None:
+            tar = tarfile.open(fileobj=fileobj, mode="r")
+            tar.extractall(tempdir)
+            tar.close()
 
-    # TODO: Handle extra_build_kwargs?
+        if buildargs is not None:
+            for key, value in buildargs.items():
+                build_cmd = build_cmd + " --build-arg " + key + "=" + value
 
-    if forcerm:
-        build_cmd = build_cmd + " --force-rm"
+        # TODO: Handle extra_build_kwargs?
 
-    if rm:
-        build_cmd = build_cmd + " --rm"
+        if forcerm:
+            build_cmd = build_cmd + " --force-rm"
 
-    if container_limits is not None:
-        if "memlimit" in container_limits:
-            build_cmd = build_cmd + " --memory " + container_limits["memlimit"]
+        if rm:
+            build_cmd = build_cmd + " --rm"
 
-    if cache_from:
-        build_cmd = build_cmd + " --cache-from"
-        for cache in cache_from:
-            build_cmd = build_cmd + " " + cache
+        if container_limits is not None:
+            if "memlimit" in container_limits:
+                build_cmd = build_cmd + " --memory " + container_limits["memlimit"]
 
-    build_cmd = build_cmd + " " + tempdir
+        if cache_from:
+            build_cmd = build_cmd + " --cache-from"
+            for cache in cache_from:
+                build_cmd = build_cmd + " " + cache
 
-    with subprocess.Popen(
-        build_cmd,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True,
-        env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"},
-    ) as p:
+        build_cmd = build_cmd + " " + tempdir
 
-        while True:
-            line = p.stdout.readline()
-            if p.poll() is not None:
-                break
-            yield {"stream": line}
+        print(build_cmd)
+        with subprocess.Popen(
+            build_cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"},
+        ) as p:
 
-        rc = p.poll()
-        if rc != 0:
-            yield {"error": line}
+            while True:
+                line = p.stdout.readline()
+                if p.poll() is not None:
+                    break
+                yield {"stream": line}
 
-    shutil.rmtree(tempdir)
+            rc = p.poll()
+            if rc != 0:
+                yield {"error": line}
+
+        shutil.rmtree(tempdir)

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -19,7 +19,7 @@ def docker_build(
     rm=False,
     container_limits=None,
     cache_from=None,
-    **extra_build_kwargs
+    **extra_build_kwargs,
 ):
 
     build_cmd = "docker build --progress plain"

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -67,7 +67,7 @@ def docker_build(
 
         while True:
             line = p.stdout.readline()
-            if not line:
+            if p.poll() is not None:
                 break
             yield {"stream": line}
 

--- a/repo2docker/docker_utils.py
+++ b/repo2docker/docker_utils.py
@@ -9,14 +9,23 @@ import subprocess
 import os
 
 
-def docker_build(fileobj=None, tag=None, custom_context=False, buildargs=None,
-                 decode=False, forcerm=False, rm=False, container_limits=None,
-                 cache_from=None, **extra_build_kwargs):
+def docker_build(
+    fileobj=None,
+    tag=None,
+    custom_context=False,
+    buildargs=None,
+    decode=False,
+    forcerm=False,
+    rm=False,
+    container_limits=None,
+    cache_from=None,
+    **extra_build_kwargs
+):
 
-    build_cmd = 'docker build --progress plain'
+    build_cmd = "docker build --progress plain"
 
     if tag is not None:
-        build_cmd = build_cmd + ' --tag ' + tag
+        build_cmd = build_cmd + " --tag " + tag
 
     tempdir = tempfile.mkdtemp()
     if fileobj is not None:
@@ -26,29 +35,35 @@ def docker_build(fileobj=None, tag=None, custom_context=False, buildargs=None,
 
     if buildargs is not None:
         for key, value in buildargs.items():
-            build_cmd = build_cmd + ' --build-arg ' + key + '=' + value
+            build_cmd = build_cmd + " --build-arg " + key + "=" + value
 
     # TODO: Handle extra_build_kwargs?
 
     if forcerm:
-        build_cmd = build_cmd + ' --force-rm'
+        build_cmd = build_cmd + " --force-rm"
 
     if rm:
-        build_cmd = build_cmd + ' --rm'
+        build_cmd = build_cmd + " --rm"
 
     if container_limits is not None:
-        if 'memlimit' in container_limits:
-            build_cmd = build_cmd + ' --memory ' + container_limits['memlimit']
+        if "memlimit" in container_limits:
+            build_cmd = build_cmd + " --memory " + container_limits["memlimit"]
 
     if cache_from:
-        build_cmd = build_cmd + ' --cache-from'
+        build_cmd = build_cmd + " --cache-from"
         for cache in cache_from:
-            build_cmd = build_cmd + ' ' + cache
+            build_cmd = build_cmd + " " + cache
 
-    build_cmd = build_cmd + ' ' + tempdir
+    build_cmd = build_cmd + " " + tempdir
 
-    with subprocess.Popen(build_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            universal_newlines=True, env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"}) as p:
+    with subprocess.Popen(
+        build_cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        env={"DOCKER_BUILDKIT": "1", "PROGRESS_NO_TRUNC": "1"},
+    ) as p:
 
         while True:
             line = p.stdout.readline()
@@ -58,6 +73,6 @@ def docker_build(fileobj=None, tag=None, custom_context=False, buildargs=None,
 
         rc = p.poll()
         if rc != 0:
-          yield {"error": line}
+            yield {"error": line}
 
     shutil.rmtree(tempdir)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -9,6 +9,7 @@ import escapism
 from repo2docker.app import Repo2Docker
 from repo2docker.__main__ import make_r2d
 from repo2docker.utils import chdir
+from repo2docker.docker_utils import DockerCLI
 
 
 def test_find_image():
@@ -84,7 +85,7 @@ def test_build_kwargs(repo_with_content):
     app = make_r2d(argv)
     app.extra_build_kwargs = {"somekey": "somevalue"}
 
-    with patch.object(docker.APIClient, "build") as builds:
+    with patch.object(DockerCLI, "build") as builds:
         builds.return_value = []
         app.build()
     builds.assert_called_once()
@@ -121,7 +122,7 @@ def test_root_not_allowed():
 
         app = Repo2Docker(repo=src, user_id=1000, user_name="jovyan", run=False)
         app.initialize()
-        with patch.object(docker.APIClient, "build") as builds:
+        with patch.object(DockerCLI, "build") as builds:
             builds.return_value = []
             app.build()
         builds.assert_called_once()
@@ -129,7 +130,7 @@ def test_root_not_allowed():
 
 def test_dryrun_works_without_docker(tmpdir, capsys):
     with chdir(tmpdir):
-        with patch.object(docker, "APIClient") as client:
+        with patch.object(DockerCLI, "__init__") as client:
             client.side_effect = docker.errors.DockerException("Error: no Docker")
             app = Repo2Docker(dry_run=True)
             app.build()
@@ -139,7 +140,7 @@ def test_dryrun_works_without_docker(tmpdir, capsys):
 
 def test_error_log_without_docker(tmpdir, capsys):
     with chdir(tmpdir):
-        with patch.object(docker, "APIClient") as client:
+        with patch.object(DockerCLI, "__init__") as client:
             client.side_effect = docker.errors.DockerException("Error: no Docker")
             app = Repo2Docker()
 

--- a/tests/unit/test_buildargs.py
+++ b/tests/unit/test_buildargs.py
@@ -1,0 +1,39 @@
+"""
+Test that build args are working
+"""
+
+from unittest.mock import patch
+from repo2docker import Repo2Docker
+from repo2docker.utils import chdir
+from repo2docker.__main__ import make_r2d
+
+
+def test_build_args(tmpdir):
+
+    with chdir(tmpdir):
+        with open("postBuild", "w") as f:
+            f.write("echo FOO=${FOO} > /tmp/foo.txt")
+
+        with patch("repo2docker.buildpacks.BuildPack.get_build_args") as gba:
+            gba.return_value = ["FOO"]
+            r2d = make_r2d(
+                [
+                    "--build-arg",
+                    "FOO=BAR",
+                    "--debug",
+                    str(tmpdir),
+                    "cat",
+                    "/tmp/foo.txt",
+                ]
+            )
+            r2d.initialize()
+            r2d.start()
+
+            # Originally used capsys, but this failed when run with other tests
+            log = r2d.log.handlers[0].stream
+            log.seek(0)
+            output = log.read()
+            # ARG should be set in debug output
+            assert "ARG FOO" in output
+            # ARG and value should be present in cat output
+            assert "FOO=BAR" in output

--- a/tests/unit/test_cache_from.py
+++ b/tests/unit/test_cache_from.py
@@ -5,6 +5,7 @@ Test that --cache-from is passed in to docker API properly.
 from unittest.mock import MagicMock
 
 import docker
+from repo2docker.docker_utils import DockerCLI
 
 from repo2docker.buildpacks import (
     BaseImage,
@@ -16,7 +17,7 @@ from repo2docker.buildpacks import (
 def test_cache_from_base(tmpdir):
     cache_from = ["image-1:latest"]
     fake_log_value = {"stream": "fake"}
-    fake_client = MagicMock(spec=docker.APIClient)
+    fake_client = MagicMock(spec=DockerCLI)
     fake_client.build.return_value = iter([fake_log_value])
     extra_build_kwargs = {"somekey": "somevalue"}
 
@@ -34,7 +35,7 @@ def test_cache_from_base(tmpdir):
 def test_cache_from_docker(tmpdir):
     cache_from = ["image-1:latest"]
     fake_log_value = {"stream": "fake"}
-    fake_client = MagicMock(spec=docker.APIClient)
+    fake_client = MagicMock(spec=DockerCLI)
     fake_client.build.return_value = iter([fake_log_value])
     extra_build_kwargs = {"somekey": "somevalue"}
     tmpdir.chdir()

--- a/tests/unit/test_memlimit.py
+++ b/tests/unit/test_memlimit.py
@@ -11,6 +11,7 @@ import docker
 import pytest
 
 from repo2docker.buildpacks import BaseImage, DockerBuildPack
+from repo2docker.docker_utils import DockerCLI
 
 
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -19,7 +20,7 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def test_memory_limit_enforced(tmpdir):
     fake_cache_from = ["image-1:latest"]
     fake_log_value = {"stream": "fake"}
-    fake_client = MagicMock(spec=docker.APIClient)
+    fake_client = MagicMock(spec=DockerCLI)
     fake_client.build.return_value = iter([fake_log_value])
     fake_extra_build_kwargs = {"somekey": "somevalue"}
 
@@ -73,7 +74,7 @@ def test_memlimit_same_postbuild():
 def test_memlimit_argument_type(BuildPack):
     # check that an exception is raised when the memory limit isn't an int
     fake_log_value = {"stream": "fake"}
-    fake_client = MagicMock(spec=docker.APIClient)
+    fake_client = MagicMock(spec=DockerCLI)
     fake_client.build.return_value = iter([fake_log_value])
 
     with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -64,29 +64,28 @@ def test_mran_date(tmpdir, runtime, expected):
     assert r.checkpoint_date == date(*expected)
 
 
-#@pytest.mark.parametrize("expected", ["2019-12-29", "2019-12-26"])
-@pytest.mark.parametrize("expected", ["2019-09-01"])
+@pytest.mark.parametrize("expected", ["2019-09-01", "2019-08-29"])
 def test_mran_latestdate(tmpdir, expected):
-    #def mock_request_head(url):
-    #    r = Response()
-    #    if url == "https://mran.microsoft.com/snapshot/" + expected:
-    #        r.status_code = 200
-    #    else:
-    #        r.status_code = 404
-    #        r.reason = "Mock MRAN no snapshot"
-    #    return r
+    def mock_request_head(url):
+        r = Response()
+        if url == "https://mran.microsoft.com/snapshot/" + expected:
+            r.status_code = 200
+        else:
+            r.status_code = 404
+            r.reason = "Mock MRAN no snapshot"
+        return r
 
     tmpdir.chdir()
 
     with open("DESCRIPTION", "w") as f:
         f.write("")
 
-    #with patch("requests.head", side_effect=mock_request_head):
-    with patch("datetime.date") as mockdate:
-        mockdate.today.return_value = date(2019, 12, 31)
-        mockdate.side_effect = lambda *args, **kw: date(*args, **kw)
-        r = buildpacks.RBuildPack()
-        r.detect()
+    with patch("requests.head", side_effect=mock_request_head):
+        with patch("datetime.date") as mockdate:
+            mockdate.today.return_value = date(2019, 12, 31)
+            mockdate.side_effect = lambda *args, **kw: date(*args, **kw)
+            r = buildpacks.RBuildPack()
+            r.detect()
     assert r.checkpoint_date.isoformat() == expected
 
 

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -64,27 +64,29 @@ def test_mran_date(tmpdir, runtime, expected):
     assert r.checkpoint_date == date(*expected)
 
 
-@pytest.mark.parametrize("expected", ["2019-12-29", "2019-12-26"])
+#@pytest.mark.parametrize("expected", ["2019-12-29", "2019-12-26"])
+@pytest.mark.parametrize("expected", ["2019-09-01"])
 def test_mran_latestdate(tmpdir, expected):
-    def mock_request_head(url):
-        r = Response()
-        if url == "https://mran.microsoft.com/snapshot/" + expected:
-            r.status_code = 200
-        else:
-            r.status_code = 404
-            r.reason = "Mock MRAN no snapshot"
-        return r
+    #def mock_request_head(url):
+    #    r = Response()
+    #    if url == "https://mran.microsoft.com/snapshot/" + expected:
+    #        r.status_code = 200
+    #    else:
+    #        r.status_code = 404
+    #        r.reason = "Mock MRAN no snapshot"
+    #    return r
 
     tmpdir.chdir()
 
     with open("DESCRIPTION", "w") as f:
         f.write("")
 
-    with patch("requests.head", side_effect=mock_request_head):
-        with patch("datetime.date") as mockdate:
-            mockdate.today.return_value = date(2019, 12, 31)
-            r = buildpacks.RBuildPack()
-            r.detect()
+    #with patch("requests.head", side_effect=mock_request_head):
+    with patch("datetime.date") as mockdate:
+        mockdate.today.return_value = date(2019, 12, 31)
+        mockdate.side_effect = lambda *args, **kw: date(*args, **kw)
+        r = buildpacks.RBuildPack()
+        r.detect()
     assert r.checkpoint_date.isoformat() == expected
 
 


### PR DESCRIPTION
This PR adds the following:
* `build-arg` flag support:  buildpacks can specify `ARG` commands and the `repo2docker` cli supports `--build-arg` flags to set these values at build time
* Docker [build-kit](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) support including moving from `docker-py` to Docker CLI for build operations

See also:
*  https://github.com/docker/docker-py/issues/2230
* https://github.com/docker/compose/pull/6865/files