### PR TITLE
Only split build args on first equals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.12.0
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache git python3 python3-dev py-pip
+RUN apk add --no-cache git python3 python3-dev py-pip build-base
 
 # build wheels in first image
 ADD . /tmp/src

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -388,7 +388,7 @@ def make_r2d(argv=None):
 
     r2d.extra_build_args = {}
     for build_arg in args.extra_build_args:
-        kv = build_arg.split("=")
+        kv = build_arg.split("=", 1)
         r2d.extra_build_args[kv[0]] = kv[1]
 
     # if the source exists locally we don't want to delete it at the end

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     name="jupyter-repo2docker",
     version=versioneer.get_version(),
     install_requires=[
+        "chardet",
         "docker",
         "traitlets",
         "python-json-logger",


### PR DESCRIPTION
**Problem**:

Extra equals (`=`) in build arg values were disappearing mysteriously.  For the STATA buildpack, I was trying to pass the license information base64 encoded, but the padding characters were removed.  This is why.