### PR TITLE
Backport pgp key handling for R

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.12.0
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache git python3 python3-dev py-pip
+RUN apk add --no-cache git python3 python3-dev py-pip build-base
 
 # build wheels in first image
 ADD . /tmp/src

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -75,6 +75,8 @@ class RBuildPack(PythonBuildPack):
             "3.6": "3.6.1-3bionic",
             "3.6.0": "3.6.0-2bionic",
             "3.6.1": "3.6.1-3bionic",
+            "4.0": "4.0.2-1.1804.0",
+            "4.0.2": "4.0.2-1.1804.0",
         }
         # the default if nothing is specified
         r_version = "3.6"
@@ -230,21 +232,25 @@ class RBuildPack(PythonBuildPack):
 
         scripts = []
         # For R 3.4 we want to use the default Ubuntu package but otherwise
-        # we use the packages from a PPA
+        # we use the packages from R's own repo
         if V(self.r_version) >= V("3.5"):
+            if V(self.r_version) >= V("4"):
+                vs = "40"
+            else:
+                vs = "35"
             scripts += [
                 (
                     "root",
-                    r"""
-                    echo "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/" > /etc/apt/sources.list.d/r3.6-ubuntu.list
+                    rf"""
+                    echo "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran{vs}/" > /etc/apt/sources.list.d/r-ubuntu.list
                     """,
                 ),
-                # Use port 80 to talk to the keyserver to increase the chances
+                # Dont use apt-key directly, as gpg does not always respect *_proxy vars. This increase the chances
                 # of being able to reach it from behind a firewall
                 (
                     "root",
                     r"""
-                    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+                    wget --quiet -O - 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xe298a3a825c0d65dfd57cbb651716619e084dab9' | apt-key add -
                     """,
                 ),
                 (


### PR DESCRIPTION
Our builds (stata15 on .stage) suddenly started failing with:

```
23 [stage-0 16/41] RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
#23 sha256:0876bef0356b30d7b42db5672f6d0ec8136a00b122dc36248563886dd6c456da
#23 1.184 Warning: apt-key output should not be parsed (stdout is not a terminal)
#23 1.336 Executing: /tmp/apt-key-gpghome.BbuuXIz84w/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
#23 2.344 gpg: connecting dirmngr at '/tmp/apt-key-gpghome.BbuuXIz84w/S.dirmngr' failed: IPC connect call failed
#23 2.345 gpg: keyserver receive failed: No dirmngr
#23 ERROR: executor failed running [/bin/sh -c apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9]: runc did not terminate sucessfully
------
> [stage-0 16/41] RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9:
------
failed to solve with frontend dockerfile.v0: failed to solve with frontend gateway.v0: rpc error: co
```

I've backported changes to `RBuildPack` from latest r2d and that resolved this issue for me.